### PR TITLE
Updating tests to php 7.2

### DIFF
--- a/tests/ChangedValuesTraitTest.php
+++ b/tests/ChangedValuesTraitTest.php
@@ -3,7 +3,7 @@ namespace Makasim\Values\Tests;
 
 use function Makasim\Values\clone_object;
 use function Makasim\Values\set_values;
-use Makasim\Values\Tests\Model\Object;
+use Makasim\Values\Tests\Model\EmptyObject;
 use PHPUnit\Framework\TestCase;
 
 class ChangedValuesTraitTest extends TestCase
@@ -12,7 +12,7 @@ class ChangedValuesTraitTest extends TestCase
     {
         $values = ['foo' => 'fooVal', 'bar' => ['bar1' => 'bar1Val', 'bar2' => 'bar2Val']];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         //guard
         self::assertChangedValuesSame([], $obj);
@@ -24,17 +24,17 @@ class ChangedValuesTraitTest extends TestCase
 
     public function testShouldTrackSetNewValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setValue('aKey', 'aVal');
 
         self::assertChangedValuesSame(['aKey' => 'aVal'], $obj);
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setValue('aNamespace.aKey', 'aVal');
 
         self::assertChangedValuesSame(['aNamespace' => ['aKey' => 'aVal']], $obj);
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setValue('aNamespace.4', 'aVal');
 
         self::assertChangedValuesSame(['aNamespace' => [4 => 'aVal']], $obj);
@@ -42,7 +42,7 @@ class ChangedValuesTraitTest extends TestCase
 
     public function testShouldResetChangedValuesOnSetValues()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setValue('aKey', 'aVal');
 
         self::assertChangedValuesSame(['aKey' => 'aVal'], $obj);
@@ -54,7 +54,7 @@ class ChangedValuesTraitTest extends TestCase
 
     public function testShouldTrackValueUnset()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setValue('aName.aKey', 'aVal');
 
         self::assertChangedValuesSame(['aName' => ['aKey' => 'aVal']], $obj);
@@ -66,7 +66,7 @@ class ChangedValuesTraitTest extends TestCase
 
     public function testShouldTrackValueAddedToEmptyArray()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->addValue('aNamespace.aKey', 'aVal');
 
         self::assertChangedValuesSame(['aNamespace' => ['aKey' => ['aVal']]], $obj);
@@ -76,7 +76,7 @@ class ChangedValuesTraitTest extends TestCase
     {
         $values = ['aNamespace' => ['aKey' => ['aVal']]];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
         $obj->addValue('aNamespace.aKey', 'aNewVal');
 
@@ -85,7 +85,7 @@ class ChangedValuesTraitTest extends TestCase
 
     public function testShouldNotReflectChangesOnClonedObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setValue('aKey', 'foo');
 
         $clonedObj = clone_object($obj);

--- a/tests/HookStorageTest.php
+++ b/tests/HookStorageTest.php
@@ -12,7 +12,7 @@ use function Makasim\Values\set_object;
 use function Makasim\Values\set_objects;
 use function Makasim\Values\set_value;
 use function Makasim\Values\set_values;
-use Makasim\Values\Tests\Model\Object;
+use Makasim\Values\Tests\Model\EmptyObject;
 use Makasim\Values\Tests\Model\SubObject;
 use PHPUnit\Framework\TestCase;
 
@@ -34,7 +34,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldRegisterHookForObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -56,7 +56,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldRegisterSeveralHooksForObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -81,7 +81,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldRegisterSeveralHooksForDifferentFunctionsToObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -110,8 +110,8 @@ class HookStorageTest extends TestCase
 
     public function testShouldRegisterSeveralHooksToSeveralObjects()
     {
-        $fooObj = new Object();
-        $barObj = new Object();
+        $fooObj = new EmptyObject();
+        $barObj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -145,11 +145,11 @@ class HookStorageTest extends TestCase
     {
         $callback = function () {};
 
-        HookStorage::register(Object::class, 'aHook', $callback);
+        HookStorage::register(EmptyObject::class, 'aHook', $callback);
 
         self::assertSame([
             'aHook' => [
-                Object::class => [
+                EmptyObject::class => [
                     spl_object_hash($callback) => $callback
                 ]
             ]
@@ -161,12 +161,12 @@ class HookStorageTest extends TestCase
         $callback = function () {};
         $anotherCallback = function () {};
 
-        HookStorage::register(Object::class, 'aHook', $callback);
-        HookStorage::register(Object::class, 'aHook', $anotherCallback);
+        HookStorage::register(EmptyObject::class, 'aHook', $callback);
+        HookStorage::register(EmptyObject::class, 'aHook', $anotherCallback);
 
         self::assertSame([
             'aHook' => [
-                Object::class => [
+                EmptyObject::class => [
                     spl_object_hash($callback) => $callback,
                     spl_object_hash($anotherCallback) => $anotherCallback,
                 ]
@@ -179,17 +179,17 @@ class HookStorageTest extends TestCase
         $callback = function () {};
         $anotherCallback = function () {};
 
-        HookStorage::register(Object::class, 'aFooHook', $callback);
-        HookStorage::register(Object::class, 'aBarHook', $anotherCallback);
+        HookStorage::register(EmptyObject::class, 'aFooHook', $callback);
+        HookStorage::register(EmptyObject::class, 'aBarHook', $anotherCallback);
 
         self::assertSame([
             'aFooHook' => [
-                Object::class => [
+                EmptyObject::class => [
                     spl_object_hash($callback) => $callback,
                 ],
             ],
             'aBarHook' => [
-                Object::class => [
+                EmptyObject::class => [
                     spl_object_hash($anotherCallback) => $anotherCallback,
                 ],
             ]
@@ -201,12 +201,12 @@ class HookStorageTest extends TestCase
         $callback = function () {};
         $anotherCallback = function () {};
 
-        HookStorage::register(Object::class, 'aHook', $callback);
+        HookStorage::register(EmptyObject::class, 'aHook', $callback);
         HookStorage::register(\stdClass::class, 'aHook', $anotherCallback);
 
         self::assertSame([
             'aHook' => [
-                Object::class => [
+                EmptyObject::class => [
                     spl_object_hash($callback) => $callback,
                 ],
                 \stdClass::class => [
@@ -218,7 +218,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldReturnEmptyArrayIfNoCallbacksRegisteredForSuchObjectAndHook()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -229,7 +229,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldReturnRegisteredHooks()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -246,7 +246,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldReturnRegisteredHooksIncludingOnesForClass()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -254,7 +254,7 @@ class HookStorageTest extends TestCase
         $anotherCallback = function () {};
 
         HookStorage::register($obj, 'aHook', $callback);
-        HookStorage::register(Object::class, 'aHook', $anotherCallback);
+        HookStorage::register(EmptyObject::class, 'aHook', $anotherCallback);
 
         $hooks = HookStorage::get($obj, 'aHook');
         self::assertInstanceOf(\Generator::class, $hooks);
@@ -263,7 +263,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldReturnRegisteredHooksIncludingGlobalOnes()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -280,7 +280,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostSetValuesCallbackOnPostSetValues()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -301,7 +301,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostSetValueCallbackOnSetValuesAndPassByReferenceArgument()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -320,7 +320,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPreAddValueCallbackOnAddValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -344,7 +344,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldAllowModifyValueInPreAddValueCallback()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -366,7 +366,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostAddValueCallbackOnAddValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -389,7 +389,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostAddValueCallbackOnAddValueWithCustomValueKey()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -410,7 +410,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPreSetValueCallbackOnSetValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -434,7 +434,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldAllowModifyValueInPreSetValueCallback()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -456,7 +456,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostSetValueCallbackOnSetValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -479,7 +479,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostGetValueCallbackOnGetValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -505,7 +505,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldAllowModifyValueInPostGetValueCallback()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         HookStorage::clearAll();
 
@@ -530,13 +530,13 @@ class HookStorageTest extends TestCase
         $isCalled = false;
         $actualObj = null;
 
-        HookStorage::register(Object::class, 'post_build_object', function() use (&$actualObj, &$isCalled) {
+        HookStorage::register(EmptyObject::class, 'post_build_object', function() use (&$actualObj, &$isCalled) {
             $isCalled = true;
 
             $actualObj = func_get_arg(0);
         });
 
-        $obj = build_object(Object::class, $values);
+        $obj = build_object(EmptyObject::class, $values);
 
         self::assertTrue($isCalled);
         self::assertSame($obj, $actualObj);
@@ -544,14 +544,14 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostBuildObjectCallbackOnBuildObjectWithContext()
     {
-        $parentObj = new Object();
+        $parentObj = new EmptyObject();
 
         $values = [];
 
         $isCalled = false;
         $actualObj = null;
 
-        HookStorage::register(Object::class, 'post_build_sub_object', function() use ($parentObj, &$actualObj, &$isCalled) {
+        HookStorage::register(EmptyObject::class, 'post_build_sub_object', function() use ($parentObj, &$actualObj, &$isCalled) {
             $isCalled = true;
 
             $actualObj = func_get_arg(0);
@@ -559,7 +559,7 @@ class HookStorageTest extends TestCase
             self::assertSame('aParentKey', func_get_arg(2));
         });
 
-        $obj = build_object_ref(Object::class, $values, $parentObj, 'aParentKey');
+        $obj = build_object_ref(EmptyObject::class, $values, $parentObj, 'aParentKey');
 
         self::assertTrue($isCalled);
         self::assertSame($obj, $actualObj);
@@ -567,7 +567,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostSetObjectCallbackOnSetObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $subObj = new SubObject();
 
         $isCalled = false;
@@ -588,7 +588,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostAddObjectCallbackOnAddObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $subObj = new SubObject();
 
         $isCalled = false;
@@ -609,7 +609,7 @@ class HookStorageTest extends TestCase
 
     public function testShouldCallPostSetObjectCallbackOnSetObjects()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         $subObj = new SubObject();
 
         $isCalled = false;
@@ -636,7 +636,7 @@ class HookStorageTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         $isCalled = false;

--- a/tests/Model/CastableObject.php
+++ b/tests/Model/CastableObject.php
@@ -4,7 +4,7 @@ namespace Makasim\Values\Tests\Model;
 use Makasim\Values\CastTrait;
 use function Makasim\Values\register_cast_hooks;
 
-class CastableObject extends Object
+class CastableObject extends EmptyObject
 {
     use CastTrait;
 

--- a/tests/Model/EmptyObject.php
+++ b/tests/Model/EmptyObject.php
@@ -5,7 +5,7 @@ use Makasim\Values\ChangedValuesTrait;
 use Makasim\Values\ObjectsTrait;
 use Makasim\Values\ValuesTrait;
 
-class Object
+class EmptyObject
 {
     use ValuesTrait {
         getValue as public;

--- a/tests/Model/OtherSubObject.php
+++ b/tests/Model/OtherSubObject.php
@@ -1,6 +1,6 @@
 <?php
 namespace Makasim\Values\Tests\Model;
 
-class OtherSubObject extends Object
+class OtherSubObject extends EmptyObject
 {
 }

--- a/tests/Model/SubObject.php
+++ b/tests/Model/SubObject.php
@@ -1,6 +1,6 @@
 <?php
 namespace Makasim\Values\Tests\Model;
 
-class SubObject extends Object
+class SubObject extends EmptyObject
 {
 }

--- a/tests/ObjectsTraitTest.php
+++ b/tests/ObjectsTraitTest.php
@@ -10,7 +10,7 @@ use Makasim\Values\HookStorage;
 use function Makasim\Values\register_hook;
 use function Makasim\Values\register_object_hooks;
 use function Makasim\Values\set_values;
-use Makasim\Values\Tests\Model\Object;
+use Makasim\Values\Tests\Model\EmptyObject;
 use Makasim\Values\Tests\Model\OtherSubObject;
 use Makasim\Values\Tests\Model\SubObject;
 use PHPUnit\Framework\TestCase;
@@ -38,7 +38,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertAttributeNotEmpty('values', $obj);
@@ -56,7 +56,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertSame($subObj, $obj->getObject('aName.aKey', SubObject::class));
@@ -67,7 +67,7 @@ class ObjectsTraitTest extends TestCase
 
     public function testShouldCreateObjectOnGet()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         $values = ['aName' => ['aKey' => ['aSubName' => ['aSubKey' => 'aFooVal']]]];
         set_values($obj, $values);
@@ -81,7 +81,7 @@ class ObjectsTraitTest extends TestCase
 
     public function testShouldReturnNullIfValueNotSet()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         self::assertNull($obj->getObject('aName.aKey', SubObject::class));
     }
@@ -91,7 +91,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertSame(['aName' => ['aKey' => ['aSubName' => ['aSubKey' => 'aFooVal']]]], get_values($obj));
@@ -108,10 +108,10 @@ class ObjectsTraitTest extends TestCase
         $subSubObj = new SubObject();
         $subSubObj->setValue('aSubSubName.aSubSubKey', 'aFooVal');
 
-        $subObj = new Object();
+        $subObj = new EmptyObject();
         $subObj->setObject('aSubName.aSubKey', $subSubObj);
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertSame(['aName' => ['aKey' => [
@@ -134,7 +134,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertSame(['aName' => ['aKey' => ['aSubName' => ['aSubKey' => 'aFooVal']]]], get_values($obj));
@@ -154,7 +154,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertSame(['aName' => ['aKey' => ['aSubName' => ['aSubKey' => 'aFooVal']]]], get_object_changed_values($obj));
@@ -165,7 +165,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         self::assertAttributeSame(['aName' => ['aKey' => $subObj]], 'objects', $obj);
@@ -181,7 +181,7 @@ class ObjectsTraitTest extends TestCase
 
         $expectedSubClass = $this->getMockClass(SubObject::class);
 
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         $values = ['aName' => ['aKey' => $subObjValues]];
         set_values($obj, $values);
@@ -203,7 +203,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObjects('aName.aKey', [$subObjFoo, $subObjBar]);
 
         $objs = $obj->getObjects('aName.aKey', SubObject::class);
@@ -226,7 +226,7 @@ class ObjectsTraitTest extends TestCase
             ['aSubName' => ['aSubKey' => 'aBarVal']],
         ]]];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         $subObjs = $obj->getObjects('aName.aKey', SubObject::class);
@@ -247,7 +247,7 @@ class ObjectsTraitTest extends TestCase
             ['aSubName' => ['aSubKey' => 'aFooVal']],
         ]]];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         $this->expectException(\LogicException::class);
@@ -265,7 +265,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->addObject('aName.aKey', $subObjFoo);
         $obj->addObject('aName.aKey', $subObjBar);
 
@@ -291,7 +291,7 @@ class ObjectsTraitTest extends TestCase
             ['aSubName' => ['aSubKey' => 'aFooVal']],
         ]]];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         $subObjBar = new SubObject();
@@ -323,7 +323,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         self::assertAttributeEmpty('changedValues', $obj);
 
@@ -343,7 +343,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         self::assertAttributeEmpty('changedValues', $obj);
 
@@ -369,7 +369,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObjects('aName.aKey', [$subObjFoo, $subObjBar]);
 
         self::assertSame(['aName' => ['aKey' => [
@@ -397,7 +397,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObjects('aName.aKey', [$subObjFoo, $subObjBar]);
 
         self::assertSame(['aName' => ['aKey' => [
@@ -429,7 +429,7 @@ class ObjectsTraitTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         //guard
@@ -468,7 +468,7 @@ class ObjectsTraitTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         //guard
@@ -504,7 +504,7 @@ class ObjectsTraitTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         //guard
@@ -527,7 +527,7 @@ class ObjectsTraitTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         //guard
@@ -556,10 +556,10 @@ class ObjectsTraitTest extends TestCase
         $subObjFoo = new SubObject();
         $subObjFoo->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('self.aKey', $subObjFoo);
 
-        self::assertSame($subObjFoo, $obj->getObject('self.aKey', Object::class));
+        self::assertSame($subObjFoo, $obj->getObject('self.aKey', EmptyObject::class));
         self::assertSame(['self' => ['aKey' =>
             ['aSubName' => ['aSubKey' => 'aFooVal']],
         ]], get_values($obj));
@@ -574,7 +574,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObjects('self.aKey', [$subObjFoo, $subObjBar]);
 
         $objs = $obj->getObjects('self.aKey', SubObject::class);
@@ -598,7 +598,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubName.aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->addObject('self.aKey', $subObjFoo);
         $obj->addObject('self.aKey', $subObjBar);
 
@@ -623,7 +623,7 @@ class ObjectsTraitTest extends TestCase
         $subObjBar = new SubObject();
         $subObjBar->setValue('aSubKey', 'aBarVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aKey', $subObjFoo);
 
         $obj->setObject('aKey', $subObjBar);
@@ -641,7 +641,7 @@ class ObjectsTraitTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         $this->expectException(\LogicException::class);
@@ -657,7 +657,7 @@ class ObjectsTraitTest extends TestCase
             ],
         ];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         register_hook('build_object', 'get_object_class', function($object, $key, $values) {
@@ -680,7 +680,7 @@ class ObjectsTraitTest extends TestCase
         $argumentClass = SubObject::class;
         $hookClass = OtherSubObject::class;
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         register_hook('build_object', 'get_object_class', function($object, $key, $values) use ($hookClass) {
@@ -697,7 +697,7 @@ class ObjectsTraitTest extends TestCase
         $subObj = new SubObject();
         $subObj->setValue('aSubName.aSubKey', 'aFooVal');
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         $obj->setObject('aName.aKey', $subObj);
 
         $values = get_values($obj); // copy must be true by default

--- a/tests/PropagateRootObjectTest.php
+++ b/tests/PropagateRootObjectTest.php
@@ -9,7 +9,7 @@ use function Makasim\Values\register_propagate_root_hooks;
 use function Makasim\Values\set_object;
 use function Makasim\Values\set_objects;
 use function Makasim\Values\set_values;
-use Makasim\Values\Tests\Model\Object;
+use Makasim\Values\Tests\Model\EmptyObject;
 use Makasim\Values\Tests\Model\SubObject;
 use PHPUnit\Framework\TestCase;
 
@@ -31,8 +31,8 @@ class PropagateRootObjectTest extends TestCase
 
     public function testShouldSetRootObjectToSubObjectOnSetObject()
     {
-        $subObj = new Object();
-        $obj = new Object();
+        $subObj = new EmptyObject();
+        $obj = new EmptyObject();
 
         register_propagate_root_hooks($obj);
 
@@ -46,7 +46,7 @@ class PropagateRootObjectTest extends TestCase
     {
         $fooSubObj = new SubObject();
         $barSubObj = new SubObject();
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         register_propagate_root_hooks($obj);
 
@@ -62,7 +62,7 @@ class PropagateRootObjectTest extends TestCase
     public function testShouldSetRootObjectToAddedObjectOnAddObject()
     {
         $fooSubObj = new SubObject();
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         register_propagate_root_hooks($obj);
 
@@ -75,7 +75,7 @@ class PropagateRootObjectTest extends TestCase
     public function testShouldSetRootObjectToEverySubObjectOnGetObjects()
     {
         $values = ['aKey' => [[], []]];
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         set_values($obj, $values);
 
@@ -97,7 +97,7 @@ class PropagateRootObjectTest extends TestCase
 
     public function testShouldSetRootObjectToSubObjectOnGetObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         $values = [
             'aKey' => []

--- a/tests/ValuesTest.php
+++ b/tests/ValuesTest.php
@@ -8,7 +8,7 @@ use function Makasim\Values\get_value;
 use function Makasim\Values\get_values;
 use function Makasim\Values\set_value;
 use function Makasim\Values\set_values;
-use Makasim\Values\Tests\Model\Object;
+use Makasim\Values\Tests\Model\EmptyObject;
 use Makasim\Values\ValuesTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +18,7 @@ class ValuesTest extends TestCase
     {
         $values = ['foo' => 'fooVal', 'bar' => ['bar1' => 'bar1Val', 'bar2' => 'bar2Val']];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         set_values($obj, $values);
 
@@ -27,7 +27,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowSetNewValueAndGetPreviouslySet()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_value($obj, 'aKey', 'aVal');
 
         self::assertSame('aVal', get_value($obj, 'aKey'));
@@ -36,7 +36,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowSetNewNameSpacedValueAndGetPreviouslySet()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_value($obj, 'aNamespace.aKey', 'aVal');
 
         self::assertSame('aVal', get_value($obj, 'aNamespace.aKey'));
@@ -45,7 +45,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowGetDefaultValueIfSimpleValueNotSet()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         self::assertSame('aDefaultVal', get_value($obj, 'aKey', 'aDefaultVal'));
 
@@ -56,7 +56,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowGetDefaultValueIfNameSpacedValueNotSet()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         self::assertSame('aDefaultVal', get_value($obj, 'aNamespace.aKey', 'aDefaultVal'));
 
@@ -67,7 +67,7 @@ class ValuesTest extends TestCase
 
     public function testShouldResetChangedValuesOnSetValues()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_value($obj, 'aNamespace.aKey', 'aVal');
 
         self::assertSame(['aNamespace' => ['aKey' => 'aVal']], get_values($obj));
@@ -80,7 +80,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowUnsetPreviouslySetSimpleValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_value($obj, 'aKey', 'aVal');
         set_value($obj, 'anotherKey', 'anotherVal');
 
@@ -95,7 +95,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowUnsetPreviouslySetNameSpacedValue()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_value($obj, 'aName.aKey', 'aVal');
         set_value($obj, 'anotherName.aKey', 'anotherVal');
 
@@ -122,7 +122,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowAddSimpleValueToEmptyArray()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         add_value($obj, 'aKey', 'aVal');
 
         self::assertSame(['aVal'], get_value($obj, 'aKey'));
@@ -131,7 +131,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowAddSeveralSimpleValuesToEmptyArray()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         add_value($obj, 'aKey', 'foo');
         add_value($obj, 'aKey', 'bar');
         add_value($obj, 'aKey', 'baz', 'customKey');
@@ -152,7 +152,7 @@ class ValuesTest extends TestCase
 
     public function testAddValueReturnsAddedValueKey()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         self::assertSame(0, add_value($obj, 'aKey', 'aVal'));
         self::assertSame('customKey', add_value($obj, 'aKey', 'aVal', 'customKey'));
@@ -161,7 +161,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowAddNameSpacedValueToEmptyArray()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         add_value($obj, 'aNamespace.aKey', 'aVal');
 
         self::assertSame(['aVal'], get_value($obj, 'aNamespace.aKey'));
@@ -172,7 +172,7 @@ class ValuesTest extends TestCase
     {
         $values = ['aKey' => ['aVal']];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         add_value($obj, 'aKey', 'aNewVal');
@@ -185,7 +185,7 @@ class ValuesTest extends TestCase
     {
         $values = ['aNamespace' => ['aKey' => ['aVal']]];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         add_value($obj, 'aNamespace.aKey', 'aNewVal');
@@ -196,7 +196,7 @@ class ValuesTest extends TestCase
 
     public function testShouldAllowAddValueWithCustomValueKeyThatContainsDot()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         add_value($obj, 'aKey', 'aVal', 'valueKey.withDot');
 
@@ -212,7 +212,7 @@ class ValuesTest extends TestCase
     {
         $values = ['aNamespace' => ['aKey' => 'aVal']];
 
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_values($obj, $values);
 
         add_value($obj, 'aNamespace.aKey', 'aVal');
@@ -220,7 +220,7 @@ class ValuesTest extends TestCase
 
     public function testShouldNotReflectChangesOnClonedObject()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
         set_value($obj, 'aNamespace.aKey', 'foo');
 
         $clonedObj = clone_object($obj);
@@ -232,7 +232,7 @@ class ValuesTest extends TestCase
 
     public function testShouldReplaceStringValueWithArray()
     {
-        $obj = new Object();
+        $obj = new EmptyObject();
 
         set_value($obj, 'aKey', 'foo');
         set_value($obj, 'aKey.aSubKey', 'bar');


### PR DESCRIPTION
Renaming "Object" class to "EmptyObject" because "Object" classname is hard-reserved in php7.2
http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.object-reserved-word